### PR TITLE
Add 'Adding a Game and Box Art' to /twitch/help

### DIFF
--- a/app/Http/Controllers/TwitchController.php
+++ b/app/Http/Controllers/TwitchController.php
@@ -169,6 +169,7 @@ class TwitchController extends Controller
     {
         $articles = [
             'About Site Suspensions, DMCA Suspensions, and Chat Bans' => 1727973,
+            'Adding a Game and Box Art to the Directory' => 2348988,
             'Authy FAQ' => 2186821,
             'Channel Banned Words' => 2100263,
             'Chat Commands' => 659095,


### PR DESCRIPTION
I find myself referencing this article often, was surprised to see it wasn't already in the list
