### PR TITLE
Update user handling for authed Twitch users

### DIFF
--- a/app/CachedTwitchUser.php
+++ b/app/CachedTwitchUser.php
@@ -35,4 +35,14 @@ class CachedTwitchUser extends Model
     protected $fillable = [
         'id', 'username'
     ];
+
+    /**
+     * The associated User model.
+     *
+     * @return App\User
+     */
+    public function user()
+    {
+        return $this->hasOne('App\User', 'id', 'id');
+    }
 }

--- a/app/Http/Controllers/TwitchAuthController.php
+++ b/app/Http/Controllers/TwitchAuthController.php
@@ -99,8 +99,7 @@ class TwitchAuthController extends Controller
         }
 
         $auth = User::firstOrCreate([
-            'id' => $user->id,
-            'username' => $user->name
+            'id' => $user->id
         ]);
         $auth->access_token = Crypt::encrypt($user->token);
         $auth->scopes = implode('+', $user->accessTokenResponseBody['scope']);

--- a/app/Http/Controllers/TwitchController.php
+++ b/app/Http/Controllers/TwitchController.php
@@ -1012,9 +1012,14 @@ class TwitchController extends Controller
         if (!empty($channel)) {
             $channel = strtolower($channel);
             $reAuth = route('auth.twitch.base') . '?redirect=subcount&scopes=user_read+channel_subscriptions';
-            $field = $id === 'true' ? 'id' : 'username';
-            $user = User::where($field, $channel)->first();
             $needToReAuth = sprintf('%s needs to authenticate to use subcount: %s', $channel, $reAuth);
+
+            try {
+                $user = $id === 'true' ? User::where('id', $channel)->first() : $this->userByName($channel)->user;
+            } catch (Exception $e) {
+                $field = $id === 'true' ? 'ID' : 'username';
+                return Helper::text('An error occurred when trying to find a channel with the ' . $field . ': ' . $channel);
+            }
 
             if (empty($user)) {
                 return Helper::text($needToReAuth);

--- a/app/User.php
+++ b/app/User.php
@@ -33,7 +33,7 @@ class User extends Authenticatable
      * @var array
      */
     protected $fillable = [
-        'id', 'username', 'access_token', 'scopes'
+        'id', 'access_token', 'scopes'
     ];
 
     /**
@@ -44,4 +44,14 @@ class User extends Authenticatable
     protected $hidden = [
         'access_token', 'scopes'
     ];
+
+    /**
+     * The associated CachedTwitchUser model
+     *
+     * @return App\CachedTwitchUser
+     */
+    public function twitch()
+    {
+        return $this->belongsTo('App\CachedTwitchUser', 'id', 'id');
+    }
 }

--- a/database/migrations/2017_03_30_121400_modify_users_table_to_remove_username.php
+++ b/database/migrations/2017_03_30_121400_modify_users_table_to_remove_username.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class ModifyUsersTableToRemoveUsername extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function($table) {
+            $table->dropColumn('username');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down() {}
+}


### PR DESCRIPTION
Currently the `users` table stores both user IDs and usernames, which is unnecessary now that we have the `CachedTwitchUser` model.

This PR modifies the behavior of `/twitch/subcount` that instead of looking up the username in the `users` table directly, it checks the Twitch user cache and then uses the user ID from that and checks the `users` table to retrieve the OAuth token and do the call that way.  
Because of this, `/twitch/subcount` and any other potential routes that require authentication with Twitch should handle name changes (and the API V3 removal) a lot better.

This also completely drops the `username` column from `users`, so it will have to rely on the `CachedTwitchUser` model or be queried by user ID directly.