### PR TITLE
Update /twitch/help to be more up-to-date

### DIFF
--- a/app/Console/Commands/UpdateTwitchHelp.php
+++ b/app/Console/Commands/UpdateTwitchHelp.php
@@ -51,7 +51,7 @@ class UpdateTwitchHelp extends Command
         $rss = new Rss;
         foreach ($topics as $topic) {
             $catId = str_replace('topic topic', null, $topic->class);
-            $catTitle = $topic->find('h5.articles')->innerHtml;
+            $catTitle = htmlspecialchars_decode($topic->find('h5.articles')->innerHtml);
 
             $this->info('Found help category/topic: ' . $catTitle);
 
@@ -64,7 +64,7 @@ class UpdateTwitchHelp extends Command
 
             foreach ($feed->articles() as $article) {
                 $id = str_replace($base . '/customer/en/portal/articles/', null, $article->link);
-                $title = $article->title;
+                $title = htmlspecialchars_decode($article->title);
 
                 $helpArticle = Article::firstOrNew(['id' => $id]);
                 $helpArticle->title = $title;

--- a/app/Console/Commands/UpdateTwitchHelp.php
+++ b/app/Console/Commands/UpdateTwitchHelp.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
 
+use Carbon\Carbon;
 use PHPHtmlParser\Dom;
 use Vinelab\Rss\Rss;
 
@@ -69,6 +70,7 @@ class UpdateTwitchHelp extends Command
                 $helpArticle = Article::firstOrNew(['id' => $id]);
                 $helpArticle->title = $title;
                 $helpArticle->category_id = $catId;
+                $helpArticle->published = Carbon::parse($article->pubDate);
                 $helpArticle->save();
 
                 $this->info('Found help article: ' . $title);

--- a/app/Console/Commands/UpdateTwitchHelp.php
+++ b/app/Console/Commands/UpdateTwitchHelp.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+use PHPHtmlParser\Dom;
+use Vinelab\Rss\Rss;
+
+use App\TwitchHelpArticle as Article;
+use App\TwitchHelpCategory as Category;
+class UpdateTwitchHelp extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'twitch:help';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Updates the Twitch help articles and categories/topics.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $dom = new Dom;
+        $base = 'https://help.twitch.tv';
+
+        $dom->loadFromUrl($base);
+        $topics = $dom->find('.topic');
+
+        $rss = new Rss;
+        foreach ($topics as $topic) {
+            $catId = str_replace('topic topic', null, $topic->class);
+            $catTitle = $topic->find('h5.articles')->innerHtml;
+
+            $this->info('Found help category/topic: ' . $catTitle);
+
+            $category = Category::firstOrNew(['id' => $catId]);
+            $category->title = $catTitle;
+            $category->save();
+
+            $feedUrl = sprintf('%s/customer/en/portal/topics/%s.rss', $base, $catId);
+            $feed = $rss->feed($feedUrl);
+
+            foreach ($feed->articles() as $article) {
+                $id = str_replace($base . '/customer/en/portal/articles/', null, $article->link);
+                $title = $article->title;
+
+                $helpArticle = Article::firstOrNew(['id' => $id]);
+                $helpArticle->title = $title;
+                $helpArticle->category_id = $catId;
+                $helpArticle->save();
+
+                $this->info('Found help article: ' . $title);
+            }
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -14,8 +14,9 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        Commands\UpdateCachedTwitchUsers::class,
         Commands\ImportSubcountTokens::class,
+        Commands\UpdateCachedTwitchUsers::class,
+        Commands\UpdateTwitchHelp::class,
     ];
 
     /**
@@ -28,5 +29,8 @@ class Kernel extends ConsoleKernel
     {
         $schedule->command('twitch:userupdate')
                  ->everyMinute();
+
+        $schedule->command('twitch:help')
+                 ->daily();
     }
 }

--- a/app/TwitchHelpArticle.php
+++ b/app/TwitchHelpArticle.php
@@ -28,6 +28,15 @@ class TwitchHelpArticle extends Model
     public $incrementing = false;
 
     /**
+     * The attributes that are mass-assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'id'
+    ];
+
+    /**
      * Scope a query to search.
      *
      * @param \Illuminate\Database\Eloquent\Builder $query

--- a/app/TwitchHelpArticle.php
+++ b/app/TwitchHelpArticle.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TwitchHelpArticle extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'twitch_help_articles';
+
+    /**
+     * The column to set as the primary key.
+     *
+     * @var string
+     */
+    protected $primaryKey = 'id';
+
+    /**
+     * Indicates if IDs are auto-incrementing.
+     *
+     * @var boolean
+     */
+    public $incrementing = false;
+
+    /**
+     * Scope a query to search.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param  String $search
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeSearch($query, $search)
+    {
+        return $query->where('title', 'LIKE', '%' . strtolower($search) . '%');
+    }
+
+    /**
+     * The associated TwitchHelpCategory model.
+     *
+     * @return App\TwitchHelpCategory
+     */
+    public function category()
+    {
+        return $this->belongsTo('App\TwitchHelpCategory', 'id', 'category_id');
+    }
+}

--- a/app/TwitchHelpCategory.php
+++ b/app/TwitchHelpCategory.php
@@ -28,6 +28,15 @@ class TwitchHelpCategory extends Model
     public $incrementing = false;
 
     /**
+     * The attributes that are mass-assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'id'
+    ];
+
+    /**
      * The associated TwitchHelpArticle models.
      *
      * @return App\TwitchHelpArticle

--- a/app/TwitchHelpCategory.php
+++ b/app/TwitchHelpCategory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TwitchHelpCategory extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'twitch_help_articles';
+
+    /**
+     * The column to set as the primary key.
+     *
+     * @var string
+     */
+    protected $primaryKey = 'id';
+
+    /**
+     * Indicates if IDs are auto-incrementing.
+     *
+     * @var boolean
+     */
+    public $incrementing = false;
+
+    /**
+     * The associated TwitchHelpArticle models.
+     *
+     * @return App\TwitchHelpArticle
+     */
+    public function articles()
+    {
+        return $this->hasMany('App\TwitchHelpArticle', 'category_id', 'id');
+    }
+}

--- a/app/TwitchHelpCategory.php
+++ b/app/TwitchHelpCategory.php
@@ -11,7 +11,7 @@ class TwitchHelpCategory extends Model
      *
      * @var string
      */
-    protected $table = 'twitch_help_articles';
+    protected $table = 'twitch_help_categories';
 
     /**
      * The column to set as the primary key.

--- a/database/migrations/2017_04_11_122956_create_twitch_help_categories_table.php
+++ b/database/migrations/2017_04_11_122956_create_twitch_help_categories_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateTwitchHelpCategoriesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('twitch_help_categories', function (Blueprint $table) {
+            $table->string('id')->unique();
+            $table->string('title')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('twitch_help_categories');
+    }
+}

--- a/database/migrations/2017_04_11_123004_create_twitch_help_articles_table.php
+++ b/database/migrations/2017_04_11_123004_create_twitch_help_articles_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateTwitchHelpArticlesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('twitch_help_articles', function (Blueprint $table) {
+            $table->string('id')->unique();
+            $table->string('title')->nullable();
+            $table->string('category_id')->nullable();
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('twitch_help_articles');
+    }
+}

--- a/database/migrations/2017_04_11_123004_create_twitch_help_articles_table.php
+++ b/database/migrations/2017_04_11_123004_create_twitch_help_articles_table.php
@@ -16,6 +16,7 @@ class CreateTwitchHelpArticlesTable extends Migration
             $table->string('id')->unique();
             $table->string('title')->nullable();
             $table->string('category_id')->nullable();
+            $table->timestamp('published');
 
             $table->timestamps();
         });


### PR DESCRIPTION
Rewrite of how the help articles in /twitch/help are loaded.
They will be updated automatically with the help of a scheduled `artisan` job and stored in a database table.

The only worry I have in terms of these changes is how accurate the search result is. Currently it will prioritize based on the "published at" datetime, with no way of manually prioritizing (unlike the config-file solution).