### PR TITLE
Add the ability to generate API keys that bypass rate limits

### DIFF
--- a/app/Console/Commands/GenerateNewRateLimitApiKey.php
+++ b/app/Console/Commands/GenerateNewRateLimitApiKey.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Ramsey\Uuid\Uuid;
+use App\RateLimitApiKeys;
+
+class GenerateNewRateLimitApiKey extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'ratelimit:generate';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generates a new API key that will bypass the rate limits applied to routes.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $name = $this->ask('Name/title of the API key?');
+        $description = $this->ask('Additional description for the API key?');
+
+        $this->info('Name/title: ' . $name);
+        $this->info('Description: ' . $description);
+
+        $confirm = $this->confirm('Is the information provided correct?');
+        if (!$confirm) {
+            return $this->error('Aborted.');
+        }
+
+        $generatedApiKey = Uuid::uuid4()->toString();
+
+        $apiKeyModel = RateLimitApiKeys::create([
+            'name' => $name,
+            'description' => $description,
+            'enabled' => true,
+            'api_key' => $generatedApiKey,
+        ]);
+
+        $this->info('Created a new API key for bypassing rate limits: ' . $generatedApiKey);
+    }
+}

--- a/app/Console/Commands/ListRateLimitApiKeys.php
+++ b/app/Console/Commands/ListRateLimitApiKeys.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\RateLimitApiKeys as ApiKey;
+
+class ListRateLimitApiKeys extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'ratelimit:list {key?}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'List the current API keys that are allowed to bypass the rate limit.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * The name of the headers displayed on output table.
+     *
+     * @var array
+     */
+    private $tableHeaders = ['ID', 'Name', 'Description', 'API Key', 'Enabled'];
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $apiKey = $this->argument('key');
+        if (empty($apiKey)) {
+            $keys = ApiKey
+                    ::all()
+                    ->toArray();
+
+            return $this->table($this->tableHeaders, $keys);
+        }
+
+        $apiKey = trim($apiKey);
+
+        if (is_numeric($apiKey)) {
+            $apiKeyModel = ApiKey::where('id', $apiKey)->get();
+        } else {
+            $apiKeyModel = ApiKey::where('api_key', $apiKey)->get();
+        }
+
+
+        if ($apiKeyModel->isEmpty()) {
+            return $this->error('The specified API key does not exist: ' . $apiKey);
+        }
+
+        $this->table($this->tableHeaders, $apiKeyModel->toArray());
+    }
+}

--- a/app/Console/Commands/SetRateLimitApiKeyStatus.php
+++ b/app/Console/Commands/SetRateLimitApiKeyStatus.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\RateLimitApiKeys as ApiKey;
+
+class SetRateLimitApiKeyStatus extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'ratelimit:set {key} {--enable}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Sets the current enabled/disabled status for an API key. By default it disables it. Use --enable to enable.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $enable = $this->option('enable');
+        $key = $this->argument('key');
+
+        $column = is_numeric($key) ? 'id' : 'api_key';
+
+        $apiKeyModel = ApiKey
+                ::where($column, $key)
+                ->first();
+
+        if (empty($apiKeyModel)) {
+            return $this->error('The specified API key does not exist: ' . $key);
+        }
+
+        $apiKeyModel->enabled = $enable;
+        $apiKeyModel->save();
+        $this->info(sprintf('The API key %s has been %s', $key, $enable ? 'enabled' : 'disabled'));
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -15,8 +15,11 @@ class Kernel extends ConsoleKernel
      */
     protected $commands = [
         Commands\DecryptString::class,
+        Commands\GenerateNewRateLimitApiKey::class,
         Commands\ImportSubcountTokens::class,
+        Commands\ListRateLimitApiKeys::class,
         Commands\RefreshIzurviveLocations::class,
+        Commands\SetRateLimitApiKeyStatus::class,
         Commands\UpdateCachedTwitchUsers::class,
         Commands\UpdateTwitchAuthUsers::class,
         Commands\UpdateTwitchHelp::class,

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -52,5 +52,6 @@ class Kernel extends HttpKernel
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'ratelimit' => \App\Http\Middleware\RateLimitWithWhitelist::class,
     ];
 }

--- a/app/Http/Middleware/RateLimitWithWhitelist.php
+++ b/app/Http/Middleware/RateLimitWithWhitelist.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+
+use App\RateLimitApiKeys as ApiKey;
+
+class RateLimitWithWhitelist extends ThrottleRequests
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  int|string  $maxAttempts
+     * @param  float|int  $decayMinutes
+     * @return mixed
+     * @throws \Illuminate\Http\Exceptions\ThrottleRequestsException
+     */
+    public function handle($request, Closure $next, $maxAttempts = 60, $decayMinutes = 1)
+    {
+        $apiKey = trim($request->header('x-api-key', ''));
+        if (empty($apiKey)) {
+            return parent::handle($request, $next, $maxAttempts, $decayMinutes);
+        }
+
+        $apiKeyModel = ApiKey
+                ::where('api_key', $apiKey)
+                ->where('enabled', true)
+                ->get();
+
+        if ($apiKeyModel->isEmpty()) {
+            return parent::handle($request, $next, $maxAttempts, $decayMinutes);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/RateLimitApiKeys.php
+++ b/app/RateLimitApiKeys.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class RateLimitApiKeys extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'rate_limit_api_keys';
+
+    /**
+     * The column to set as the primary key.
+     *
+     * @var string
+     */
+    protected $primaryKey = 'id';
+
+    /**
+     * The attributes that are mass-assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+        'description',
+        'api_key',
+        'enabled',
+    ];
+
+    /**
+     * The attributes that should be visible in arrays.
+     *
+     * @var array
+     */
+    protected $visible = [
+        'id',
+        'name',
+        'description',
+        'api_key',
+        'enabled',
+    ];
+}

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "doctrine/dbal": "^2.5",
         "fideloper/proxy": "~4.0",
         "tom-lingham/searchy": "^2.0",
-        "sentry/sentry-laravel": "^0.9.0"
+        "sentry/sentry-laravel": "^0.9.0",
+        "ramsey/uuid": "^3.7"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "950fcdefdea8b1efb2fc67244661f27c",
+    "content-hash": "35d770cd1155abcc223c15f1ee8821a7",
     "packages": [
         {
             "name": "alaouy/youtube",

--- a/database/migrations/2018_07_03_004238_create_rate_limit_api_keys_table.php
+++ b/database/migrations/2018_07_03_004238_create_rate_limit_api_keys_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateRateLimitApiKeysTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('rate_limit_api_keys', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('description')->nullable();
+            $table->string('api_key')->unique();
+            $table->boolean('enabled')->default(false);
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('rate_limit_api_keys');
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -105,7 +105,7 @@ Route::group(['prefix' => 'steam', 'as' => 'steam.'], function() {
         ->where('id', '([0-9]+)');
 });
 
-Route::group(['prefix' => 'twitch', 'as' => 'twitch.', 'middleware' => 'throttle:' . env('THROTTLE_RATE_LIMIT', '100,1')], function() {
+Route::group(['prefix' => 'twitch', 'as' => 'twitch.', 'middleware' => 'ratelimit:' . env('THROTTLE_RATE_LIMIT', '100,1')], function() {
     // Include some extra characters that are used in examples quite often.
     // The error returned should hopefully clear up any confusion as to why it doesn't work.
     $channelRegex = '([$:{}A-z0-9]{1,50})';


### PR DESCRIPTION
This feature essentially allows holders of (valid) API keys to bypass any rate limits that have been applied to certain routes (for now it's only `/twitch` lol).

Most users never hit the rate-limit or even get close to it, since it's relatively generous.  
There have been a few edge cases where I've noticed someone spamming requests, but it has usually been unintentional (such as a bug).

A minor difference that this makes when a valid API key is specified, is that the `X-RateLimit-*` and `RetryAfter` headers are not included in the responses.  
In theory this shouldn't be a problem for any developers to deal with.