### PR TITLE
Add basic localization support

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -19,6 +19,8 @@ class Helper
      * From: http://www.if-not-true-then-false.com/2010/php-calculate-real-differences-between-two-dates-or-timestamps/
      * Code snippet credit: https://gist.github.com/ozh/8169202
      *
+     * Modified to support localization strings in Laravel.
+     *
      * @param mixed $time1 a time (string or timestamp)
      * @param mixed $time2 a time (string or timestamp)
      * @param integer $precision Optional precision
@@ -69,11 +71,8 @@ class Helper
             }
             // Add value and interval if value is bigger than 0
             if($value > 0) {
-                if($value != 1){
-                    $interval .= "s";
-                }
                 // Add value and interval to times array
-                $times[] = $value . " " . $interval;
+                $times[] = trans_choice('time.' . $interval, $value, ['value' => $value]);
                 $count++;
             }
         }

--- a/app/Http/Controllers/TwitchController.php
+++ b/app/Http/Controllers/TwitchController.php
@@ -177,7 +177,7 @@ class TwitchController extends Controller
         if (empty($user)) {
             $nb = new Nightbot($request);
             if (empty($nb->user)) {
-                return Helper::text('You need to specify a username!');
+                return Helper::text(__('generic.username_required'));
             }
 
             $user = $user ?: $nb->user['providerId'];
@@ -214,7 +214,7 @@ class TwitchController extends Controller
     public function avatar(Request $request, $user = null)
     {
         if (empty($user)) {
-            return Helper::text('No user specified');
+            return Helper::text(__('generic.username_required'));
         }
 
         $id = $request->input('id', 'false');
@@ -251,7 +251,7 @@ class TwitchController extends Controller
         $channel = $channel ?: $request->input('channel', null);
 
         if (empty($channel)) {
-            return Helper::text('Channel name has to be specified.');
+            return Helper::text(__('generic.channel_name_required'));
         }
 
         $url = sprintf('https://api.twitch.tv/api/channels/%s/chat_properties', $channel);
@@ -264,7 +264,7 @@ class TwitchController extends Controller
         $rules = $data['chat_rules'];
 
         if (empty($rules)) {
-            return Helper::text($channel . ' does not have any rules set.');
+            return Helper::text(__('twitch.no_chat_rules', ['channel' => $channel]));
         }
 
         $rules = implode(PHP_EOL, $rules);
@@ -284,7 +284,7 @@ class TwitchController extends Controller
         $channel = $channel ?: $request->input('channel', null);
 
         if (empty($channel)) {
-            return $this->error('A channel has to be specified');
+            return $this->error(__('generic.channel_name_required'));
         }
 
         $cluster = Helper::get('https://tmi.twitch.tv/servers?channel=' . $channel, [
@@ -292,7 +292,7 @@ class TwitchController extends Controller
         ]);
 
         if (empty($cluster)) {
-            return $this->error('An error occurred retrieving cluster.');
+            return $this->error(__('twitch.error_occurred_chat_clusters'));
         }
 
         return Helper::text($cluster['cluster']);
@@ -316,13 +316,13 @@ class TwitchController extends Controller
         $allTimezones = DateTimeZone::listIdentifiers();
 
         if (!in_array($tz, $allTimezones)) {
-            return Helper::text('Invalid timezone specified: ' . $tz);
+            return Helper::text(__('time.invalid_timezone', ['timezone' => $tz]));
         }
 
         if (empty($user)) {
             $nb = new Nightbot($request);
             if (empty($nb->user)) {
-                return Helper::text('You need to specify a username!');
+                return Helper::text(__('generic.username_required'));
             }
 
             $user = $user ?: $nb->user['providerId'];
@@ -352,6 +352,8 @@ class TwitchController extends Controller
 
     /**
      * Uses the specified subscriber count to see how many subscribers are needed to open a certain amount of emoteslots.
+     *
+     * ! NOTE: Scheduled for deprecation/removal.
      *
      * @param  Request $request
      * @param  string  $channel The channel name
@@ -418,7 +420,7 @@ class TwitchController extends Controller
         if (empty($channel) || empty($user)) {
             $nb = new Nightbot($request);
             if (empty($nb->channel) || empty($nb->user)) {
-                return Helper::text('You need to specify both user and channel name');
+                return Helper::text(__('generic.user_channel_name_required'));
             }
 
             $channel = $channel ?: $nb->channel['providerId'];
@@ -430,7 +432,7 @@ class TwitchController extends Controller
         $user = trim($user);
 
         if (strtolower($channel) === strtolower($user)) {
-            return Helper::text('A user cannot follow themself.');
+            return Helper::text(__('twitch.cannot_follow_self'));
         }
 
         if ($id !== 'true') {
@@ -465,7 +467,7 @@ class TwitchController extends Controller
         if (empty($channel)) {
             $nb = new Nightbot($request);
             if (empty($nb->channel)) {
-                return Helper::text('A channel has to be specified.');
+                return Helper::text(__('generic.channel_name_required'));
             }
 
             $channel = $nb->channel['providerId'];
@@ -511,7 +513,7 @@ class TwitchController extends Controller
         if (empty($user) || empty($channel)) {
             $nb = new Nightbot($request);
             if (empty($nb->channel) || empty($nb->user)) {
-                return Helper::text('You need to specify both user and channel name');
+                return Helper::text(__('twitch.user_channel_name_required'));
             }
 
             $channel = $channel ?: $nb->channel['providerId'];
@@ -520,11 +522,11 @@ class TwitchController extends Controller
         }
 
         if (!in_array($tz, $allTimezones)) {
-            return Helper::text('Invalid timezone specified: ' . $tz);
+            return Helper::text(__('time.invalid_timezone', ['timezone' => $tz]));
         }
 
         if (strtolower($user) === strtolower($channel)) {
-            return Helper::text('A user cannot follow themself.');
+            return Helper::text(__('twitch.cannot_follow_self'));
         }
 
         if ($id !== 'true') {
@@ -578,7 +580,7 @@ class TwitchController extends Controller
         if (empty($channel)) {
             $nb = new Nightbot($request);
             if (empty($nb->channel)) {
-                return Helper::text('A channel has to be specified.');
+                return Helper::text(__('generic.channel_name_required'));
             }
 
             $channel = $nb->channel['providerId'];
@@ -595,10 +597,10 @@ class TwitchController extends Controller
 
         if ($count > 100) {
             if ($request->wantsJson()) {
-                return Helper::json(['error' => 'Count cannot be more than 100.'], 400);
+                return Helper::json(['error' => __('generic.max_count', ['value' => 100])], 400);
             }
 
-            return Helper::text('Count cannot be more than 100.');
+            return Helper::text(__('generic.max_count', ['value' => 100]));
         }
 
         $followers = $this->twitchApi->channelFollows($channel, $count, $offset, $direction, $this->version, $cursor);
@@ -613,10 +615,10 @@ class TwitchController extends Controller
 
         if (!isset($followers['follows'])) {
             if ($request->wantsJson()) {
-                return Helper::json(['error' => 'An error occurred retrieving your followers.', 500]);
+                return Helper::json(['error' => __('twitch.error_followers'), 500]);
             }
 
-            return Helper::text('An error occurred retrieving your followers.');
+            return Helper::text(__('twitch.error_followers'));
         }
 
         $follows = $followers['follows'];
@@ -630,7 +632,7 @@ class TwitchController extends Controller
                 ]);
             }
 
-            return Helper::text('You do not have any followers :(');
+            return Helper::text(__('twitch.no_followers'));
         }
 
         $users = [];
@@ -711,7 +713,7 @@ class TwitchController extends Controller
         $textField = $request->input('field', 'name');
 
         if ($limit < 0 || $limit > 100) {
-            $errorText = 'Invalid "limit" specified: ' . $limit;
+            $errorText = __('generic.invalid_limit', ['limit' => $limit]);
             if ($request->wantsJson()) {
                 return Helper::json(['error' => $errorText], 400);
             }
@@ -720,7 +722,7 @@ class TwitchController extends Controller
         }
 
         if ($offset < 0) {
-            $errorText = 'Invalid "offset" specified: ' . $offset;
+            $errorText = __('generic.invalid_offset', ['offset' => $offset]);
             if ($request->wantsJson()) {
                 return Helper::json(['error' => $errorText], 400);
             }
@@ -745,12 +747,12 @@ class TwitchController extends Controller
 
             if ($request->wantsJson()) {
                 return Helper::json([
-                    'error' => 'Twitch API returned invalid data.',
+                    'error' => __('twitch.invalid_api_data'),
                     'status' => 500,
                 ], 500);
             }
 
-            return Helper::text('Unable to get follow data for the specified user.');
+            return Helper::text(__('twitch.unable_get_following'));
         }
 
         if (count($follows) === 0) {
@@ -758,7 +760,7 @@ class TwitchController extends Controller
                 return Helper::json($follows);
             }
 
-            return Helper::text('End of following list.');
+            return Helper::text(__('twitch.end_following_list'));
         }
 
         $list = [];
@@ -811,7 +813,7 @@ class TwitchController extends Controller
         if (empty($channel)) {
             $nb = new Nightbot($request);
             if (empty($nb->channel)) {
-                return Helper::text('Channel name has to be specified.');
+                return Helper::text(__('generic.channel_name_required'));
             }
 
             $channel = $nb->channel['providerId'];
@@ -833,7 +835,7 @@ class TwitchController extends Controller
         }
 
         $text = $getGame[$route];
-        return Helper::text($text ?: 'Not set');
+        return Helper::text($text ?: __('generic.not_set'));
     }
 
     /**
@@ -872,7 +874,7 @@ class TwitchController extends Controller
 
             $data = [
                 'list' => $data['articles'],
-                'page' => 'Help Articles',
+                'page' => __('twitch.help_articles'),
                 'prefix' => $prefix
             ];
             return view('shared.list', $data);
@@ -882,7 +884,7 @@ class TwitchController extends Controller
         $code = null;
 
         if (empty($search) || $search === 'list') {
-            return Helper::text('List of available help articles with titles: ' . route('twitch.help') . '?list');
+            return Helper::text(__('help_available_list', ['url' => route('twitch.help') . '?list']));
         }
 
         $articles = HelpArticle::search($search)
@@ -892,7 +894,7 @@ class TwitchController extends Controller
                     ->get();
 
         if ($articles->isEmpty()) {
-            $msg = 'No results found.';
+            $msg = __('twitch.help_no_results');
             $code = 404;
         }
 
@@ -942,7 +944,7 @@ class TwitchController extends Controller
         if (empty($channel)) {
             $nb = new Nightbot($request);
             if (empty($nb->channel)) {
-                return Helper::text('You have to specify a channel');
+                return Helper::text('generic.channel_name_required');
             }
 
             $channel = $nb->channel['providerId'];
@@ -966,7 +968,7 @@ class TwitchController extends Controller
         }
 
         if (empty($fetchHighlight['videos'])) {
-            return Helper::text(($channelName ?: $channel) . ' has no saved highlights');
+            return Helper::text(__('twitch.no_highlights', ['channel' => ($channelName ?: $channel)]));
         }
 
         $highlight = $fetchHighlight['videos'][0];
@@ -994,7 +996,7 @@ class TwitchController extends Controller
         if (empty($channel)) {
             $nb = new Nightbot($request);
             if (empty($nb->channel)) {
-                return Helper::text('A channel name has to be specified.');
+                return Helper::text(__('generic.channel_name_required'));
             }
 
             $channel = $nb->channel['providerId'];
@@ -1018,7 +1020,7 @@ class TwitchController extends Controller
         }
 
         if (empty($data['videos'])) {
-            return Helper::text(($channelName ?: $channel) . ' has no saved highlights.');
+            return Helper::text(__('twitch.no_highlights', ['channel' => ($channelName ?: $channel)]));
         }
 
         $highlights = $data['videos'];
@@ -1062,7 +1064,7 @@ class TwitchController extends Controller
 
         $nb = new Nightbot($request);
         if (empty($channel)) {
-            $message = 'Channel cannot be empty';
+            $message = __('generic.channel_name_required');
             if ($wantsJson) {
                 return $this->errorJson(['message' => $message, 'status' => 404], 404);
             }
@@ -1102,7 +1104,7 @@ class TwitchController extends Controller
                 return Helper::json([]); // just send an empty host list
             }
 
-            return Helper::text('No one is currently hosting ' . ($channelName ?: $channel));
+            return Helper::text(__('twitch.no_hosts', ['channel' => ($channelName ?: $channel)]));
         }
 
         $hostList = [];
@@ -1125,8 +1127,11 @@ class TwitchController extends Controller
 
         $names = array_slice($hostList, 0, $limit);
         $others = count($hostList) - $limit;
-        $format = '%s and %d other' . ($others > 1 ? 's' : '');
-        $text = sprintf($format, implode($separator, $names), $others);
+        $text = __('twitch.multiple_hosts', [
+            'channels' => implode($separator, $names),
+            'amount' => $others,
+        ]);
+
         return Helper::text($text);
     }
 

--- a/app/Http/Controllers/TwitchController.php
+++ b/app/Http/Controllers/TwitchController.php
@@ -1148,7 +1148,7 @@ class TwitchController extends Controller
         $id = $request->input('id', 'false');
 
         if (empty($channel)) {
-            return Helper::text('Channel name cannot be empty.');
+            return Helper::text(__('generic.channel_name_required'));
         }
 
         if ($id !== 'true') {
@@ -1175,7 +1175,7 @@ class TwitchController extends Controller
         $user = $user ?: $request->input('user', null);
 
         if (empty($user)) {
-            return Helper::text('Username has to be specified.');
+            return Helper::text(__('generic.username_required'));
         }
 
         try {
@@ -1195,7 +1195,7 @@ class TwitchController extends Controller
     {
         $ingests = $this->twitchApi->ingests();
         if (empty($ingests['ingests'])) {
-            return $this->error('An error occurred attempting to load the data.');
+            return $this->error(__('generic.error_loading_data'));
         }
 
         $info = '';
@@ -1246,11 +1246,13 @@ class TwitchController extends Controller
         $services['multistre.am'] = $services['multistream'];
 
         if (empty($services[$service])) {
-            return Helper::text('Invalid service specified - Available services: ' . implode(', ', array_keys($services)));
+            return Helper::text(__('twitch.multi_invalid_service', [
+                'services' => implode(', ', array_keys($services)),
+            ]));
         }
 
         if (empty($streams)) {
-            return Helper::text('You have to specify which streams to create a multi link for (space-separated list).');
+            return Helper::text(__('twitch.multi_empty_list'));
         }
 
         $service = $services[$service];
@@ -1288,7 +1290,9 @@ class TwitchController extends Controller
         $action = isset($request->route()->getAction()['action']) ? $request->route()->getAction()['action'] : 'random';
 
         if (!in_array($action, $actions)) {
-            return Helper::text(sprintf('Invalid action specified, available actions: %s.', implode(', ', $actions)));
+            return Helper::text(__('twitch.sub_invalid_action', [
+                'actions' => implode(', ', $actions),
+            ]));
         }
 
          if ($request->exists('logout')) {
@@ -1323,7 +1327,7 @@ class TwitchController extends Controller
             if (empty($channel)) {
                 $nb = new Nightbot($request);
                 if (empty($nb->channel)) {
-                    return Helper::text('You need to specify a channel name or an OAuth token');
+                    return Helper::text(__('generic.user_channel_name_required'));
                 }
                 $channel = $nb->channel['providerId'];
                 $id = true;

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -31,6 +31,7 @@ class Kernel extends HttpKernel
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \App\Http\Middleware\IPBasedBlacklist::class,
+            \App\Http\Middleware\SetLocaleMiddleware::class,
         ],
 
         'api' => [

--- a/app/Http/Middleware/SetLocaleMiddleware.php
+++ b/app/Http/Middleware/SetLocaleMiddleware.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App;
+use Closure;
+
+class SetLocaleMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $locale = $request->input('lang', 'en');
+        App::setLocale($locale);
+
+        return $next($request);
+    }
+}

--- a/resources/lang/de/time.php
+++ b/resources/lang/de/time.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * German translation strings for time, for example: /twitch/followage & /twitch/uptime
+ */
+return [
+    'year' => ':value Jahr|:value Jahre',
+    'month' => ':value Monat|:value Monate',
+    'week' => ':value Woche|:value Wochen',
+    'day' => ':value Tag|:value Tage',
+    'hour' => ':value Stunde|:value Stunden',
+    'minute' => ':value Minute|:value Minuten',
+    'second' => ':value Sekunde|:value Sekunden',
+];

--- a/resources/lang/en/generic.php
+++ b/resources/lang/en/generic.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * English translation strings for generic errors/status messages.
+ */
+return [
+    'username_required' => 'A username has to be specified.',
+    'channel_name_required' => 'A channel name has to be specified.',
+    'user_channel_name_required' => 'Both username and channel name must be specified.',
+    'max_count' => 'Count cannot be more than :value.',
+    'invalid_limit' => 'Invalid "limit" specified: :limit',
+    'invalid_offset' => 'Invalid "offset" specified: :offset',
+];

--- a/resources/lang/en/generic.php
+++ b/resources/lang/en/generic.php
@@ -10,4 +10,5 @@ return [
     'max_count' => 'Count cannot be more than :value.',
     'invalid_limit' => 'Invalid "limit" specified: :limit',
     'invalid_offset' => 'Invalid "offset" specified: :offset',
+    'error_loading_data' => 'An error occurred loading the requested data.',
 ];

--- a/resources/lang/en/generic.php
+++ b/resources/lang/en/generic.php
@@ -11,4 +11,5 @@ return [
     'invalid_limit' => 'Invalid "limit" specified: :limit',
     'invalid_offset' => 'Invalid "offset" specified: :offset',
     'error_loading_data' => 'An error occurred loading the requested data.',
+    'error_loading_data_api' => 'An error occurred retrieving data from the API.',
 ];

--- a/resources/lang/en/time.php
+++ b/resources/lang/en/time.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * English translation strings for time, for example: /twitch/followage & /twitch/uptime
+ */
+return [
+    'year' => ':value year|:value years',
+    'month' => ':value month|:value months',
+    'week' => ':value week|:value weeks',
+    'day' => ':value day|:value days',
+    'hour' => ':value hour|:value hours',
+    'minute' => ':value minute|:value minutes',
+    'second' => ':value second|:value seconds',
+];

--- a/resources/lang/en/time.php
+++ b/resources/lang/en/time.php
@@ -11,4 +11,5 @@ return [
     'hour' => ':value hour|:value hours',
     'minute' => ':value minute|:value minutes',
     'second' => ':value second|:value seconds',
+    'invalid_timezone' => 'Invalid timezone specified: :timezone',
 ];

--- a/resources/lang/en/twitch.php
+++ b/resources/lang/en/twitch.php
@@ -37,4 +37,15 @@ return [
      */
     'no_hosts' => 'No one is currently hosting :channel',
     'multiple_hosts' => ':channels and :amount other|:channels and :amount others',
+
+    /**
+     * Multi
+     */
+    'multi_invalid_service' => 'Invalid service specified - Available services: :services',
+    'multi_empty_list' => 'You have to specify which streams to create a multi link for (space-separated list).',
+
+    /**
+     * Subscriber-related stuff
+     */
+    'sub_invalid_action' => 'Invalid action specified. Available actions: :actions',
 ];

--- a/resources/lang/en/twitch.php
+++ b/resources/lang/en/twitch.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * English translation strings for generic Twitch-related errors.
+ */
+return [
+    /**
+     * Related to chat
+     */
+    'no_chat_rules' => ':channel does not have any chat rules set.',
+    'error_occurred_chat_clusters' => 'An error occurred retrieving chat clusters.',
+
+    /**
+     * Related to followers
+     */
+    'cannot_follow_self' => 'A user cannot follow themself.',
+    'error_followers' => 'An error occurred retrieving your followers.',
+    'no_followers' => 'You do not have any followers :(',
+    'invalid_api_data' => 'Twitch API returned invalid data.',
+    'unable_get_following' => 'Unable to get follow data for the specified user.',
+    'end_following_list' => 'End of following list.',
+
+    /**
+     * Help articles
+     */
+    'help_articles' => 'Help Articles',
+    'help_available_list' => 'List of available help articles with titles: :url',
+    'help_no_results' => 'No results found.',
+
+    /**
+     * Media (highlights, VODs, uploads)
+     */
+    'no_highlights' => ':channel has no saved highlights.',
+
+    /**
+     * Hosting
+     */
+    'no_hosts' => 'No one is currently hosting :channel',
+    'multiple_hosts' => ':channels and :amount other|:channels and :amount others',
+];

--- a/resources/lang/en/twitch.php
+++ b/resources/lang/en/twitch.php
@@ -9,6 +9,9 @@ return [
      */
     'no_chat_rules' => ':channel does not have any chat rules set.',
     'error_occurred_chat_clusters' => 'An error occurred retrieving chat clusters.',
+    'error_retrieving_chat_users' => 'There was an error retrieving users for channel: ',
+    'empty_chat_user_list' => 'The list of users is empty.',
+    'channel_missing_subemotes' => 'This channel does not have any subscriber emotes.',
 
     /**
      * Related to followers
@@ -31,6 +34,13 @@ return [
      * Media (highlights, VODs, uploads)
      */
     'no_highlights' => ':channel has no saved highlights.',
+    'no_uploads' => ':channel has no uploaded videos.',
+    'no_vods' => ':channel has no available VODs.',
+    'invalid_limit_parameter' => 'Invalid "limit" parameter specified. Minimum :min, maximum :max.',
+    'invalid_offset_parameter' => 'Invalid "offset" parameter specified. Minimum :min.',
+    'end_of_video_list' => 'Reached the end of the video list!',
+    'invalid_minutes_parameter' => 'Invalid amount of minutes specified: :min',
+    'vodreplay_minutes_too_high' => 'The minutes (:min) specified is longer than the length of the VOD.',
 
     /**
      * Hosting
@@ -48,4 +58,21 @@ return [
      * Subscriber-related stuff
      */
     'sub_invalid_action' => 'Invalid action specified. Available actions: :actions',
+    'sub_needs_authentication' => '%s needs to authenticate to use %sSub (%s sub): %s',
+    'sub_count_too_high' => 'Count specified (%d) is higher than the amount of subscribers (%d)',
+    'subage_needs_authentication' => '%s needs to authenticate to use subage (Subscription length): %s',
+    'subcount_missing_channel' => 'Use ?channel=CHANNEL_NAME or /twitch/subcount/CHANNEL_NAME to get subcount.',
+    'subcount_needs_authentication' => '%s needs to authenticate to use subcount: %s',
+    'subpoints_missing_channel' => 'Please specify a channel name at the end of the URL - For example: /twitch/subpoints/CHANNEL_NAME',
+    'subpoints_needs_authentication' => '%s needs to authenticate to use subpoints: %s',
+
+    /**
+     * Authentication
+     */
+    'auth_missing_scopes' => 'The OAuth token is missing a required scope(s):',
+
+    /**
+     * Teams
+     */
+    'teams_missing_identifier' => 'Team identifier is empty',
 ];

--- a/resources/lang/no/generic.php
+++ b/resources/lang/no/generic.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Norwegian translation strings for generic errors/status messages.
+ */
+return [
+    'username_required' => 'Du må oppgi et brukernavn.',
+    'channel_name_required' => 'Du må oppgi et kanalnavn.',
+    'user_channel_name_required' => 'Både brukernavn og kanalnavn må spesifiseres.',
+    'max_count' => 'Antall kan ikke være mer enn :value.',
+    'invalid_limit' => 'Ugyldig "limit" oppgitt: :limit',
+    'invalid_offset' => 'Ugyldig "offset" oppgitt: :offset',
+];

--- a/resources/lang/no/time.php
+++ b/resources/lang/no/time.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * Norwegian translation strings for time, for example: /twitch/followage & /twitch/uptime
+ */
+return [
+    'year' => ':value år|:value år',
+    'month' => ':value måned|:value måneder',
+    'week' => ':value uke|:value uker',
+    'day' => ':value dag|:value dager',
+    'hour' => ':value time|:value timer',
+    'minute' => ':value minutt|:value minutter',
+    'second' => ':value sekund|:value sekunder',
+];

--- a/resources/lang/no/time.php
+++ b/resources/lang/no/time.php
@@ -11,4 +11,5 @@ return [
     'hour' => ':value time|:value timer',
     'minute' => ':value minutt|:value minutter',
     'second' => ':value sekund|:value sekunder',
+    'invalid_timezone' => 'Ugyldig tidssone oppgitt: :timezone',
 ];

--- a/resources/lang/no/twitch.php
+++ b/resources/lang/no/twitch.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Norwegian translation strings for Twitch-related errors.
+ */
+return [
+    /**
+     * Chat-related
+     */
+    'no_chat_rules' => ':channel har ikke definert noen chatregler.',
+
+    /**
+     * Related to followers
+     */
+    'cannot_follow_self' => 'En bruker kan ikke følge seg selv.',
+    'error_followers' => 'En feil oppstod ved henting av følgere.',
+    'no_followers' => 'Du har ingen følgere :(',
+    'invalid_api_data' => 'Twitch API returnerte ugyldig data.',
+    'unable_get_following' => 'Får ikke hentet gyldig data for den oppgitte brukeren.',
+    'end_following_list' => 'Du har nådd slutten av listen over følgede kanaler.',
+
+    /**
+     * Help articles
+     */
+    'help_articles' => 'Hjelpeartikler',
+    'help_available_list' => 'Liste over tilgjengelige hjelpeartikler med titler: :url',
+    'help_no_results' => 'Ingen resultater funnet.',
+
+    /**
+     * Media (highlights, VODs, uploads)
+     */
+    'no_highlights' => ':channel har ingen lagrede høydepunkter.',
+
+    /**
+     * Hosting
+     */
+    'no_hosts' => 'Det er foreløpig ingen som hoster :channel',
+    'multiple_hosts' => ':channels og :amount annen|:channels og :amount andre',
+];


### PR DESCRIPTION
This adds basic translation/localization support for the most used routes (`/twitch`).  
(I'm not completely done with all the routes yet, but making the PR for reference sake).

In the beginning I've only added English (duh), Norwegian and some German (with help from others).

Eventually I need to integrate some sort of tool for allowing people to easily translate to their languages, but that's for another day.

Closes #21 