### PR TITLE
Move /twitch/subscriber_emotes to Twitch's products API

### DIFF
--- a/app/Http/Controllers/TwitchApiController.php
+++ b/app/Http/Controllers/TwitchApiController.php
@@ -83,6 +83,21 @@ class TwitchApiController extends Controller
     }
 
     /**
+     * Returns data from the 1st party, yet unofficial 'Products' API endpoint.
+     * ! Depending on Twitch's mood, this may or may not disappear soon.
+     *
+     * @param string $channel
+     *
+     * @return TwitchApiController\get
+     */
+    public function channelProduct($channel = '')
+    {
+        $url = sprintf('https://api.twitch.tv/api/channels/%s/product', $channel);
+
+        return $this->get($url, true);
+    }
+
+    /**
      * Returns the "/channel/:channel/follows" object.
      *
      * @param  string $channel


### PR DESCRIPTION
Legacy endpoint that might break for the time being, but the easiest fix to implement for this endpoint while I move to TwitchEmotes.com (or something else).

Closes #49 	