### PR TITLE
Add rate-limit to /steam routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ PAPERTRAIL_LOG_DESTINATION=""
 THROTTLE_RATE_LIMIT="100,1"
 # `STEAM_THROTTLE_RATE_LIMIT` applies a different rate limit to /steam routes
 # This is a separate rate limit and the rate limits aren't shared between /twitch and /steam.
-STEAM_THROTTLE_RATE_LIMIT="45,1"
+STEAM_THROTTLE_RATE_LIMIT="15,1"
 
 # Twitch API
 # https://glass.twitch.tv/console/apps

--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,11 @@ DECAPI_USER_AGENT="DecAPI/1.0.0 (https://github.com/Decicus/DecAPI)"
 PAPERTRAIL_LOG_DESTINATION=""
 # Rate limit. By default it's "100,1", which means 100 requests per 1 minute.
 # Rate limits only affect certain endpoints. See README on GitHub: https://github.com/Decicus/DecAPI#rate-limits
+# `THROTTLE_RATE_LIMIT` as of right now only affects /twitch
 THROTTLE_RATE_LIMIT="100,1"
+# `STEAM_THROTTLE_RATE_LIMIT` applies a different rate limit to /steam routes
+# This is a separate rate limit and the rate limits aren't shared between /twitch and /steam.
+STEAM_THROTTLE_RATE_LIMIT="45,1"
 
 # Twitch API
 # https://glass.twitch.tv/console/apps

--- a/readme.md
+++ b/readme.md
@@ -31,8 +31,8 @@ Anything that for some reason did not get included in this rewrite, will still b
 
 The following things are required for setting this up:
 
-- [Laravel 5.6's requirements](https://laravel.com/docs/5.6/installation#server-requirements)
-- [A database system that Laravel supports](https://laravel.com/docs/5.6/database#introduction)
+- [Laravel 5.8's requirements](https://laravel.com/docs/5.8/installation#server-requirements)
+- [A database system that Laravel supports](https://laravel.com/docs/5.8/database#introduction)
 - [Composer](https://getcomposer.org/)
 
 ## Setup

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ Anything that for some reason did not get included in this rewrite, will still b
 The following things are required for setting this up:
 
 - [Laravel 5.6's requirements](https://laravel.com/docs/5.6/installation#server-requirements)
-- [A database system that Laravel supports](https://laravel.com/docs/5.2/database#introduction)
+- [A database system that Laravel supports](https://laravel.com/docs/5.6/database#introduction)
 - [Composer](https://getcomposer.org/)
 
 ## Setup
@@ -85,8 +85,13 @@ Rate limiting is done by using Laravel's `throttle` middleware. This means you c
 
 Below is an overview over what routes are currently rate limited. If the route is not specified, it does not have a rate limit.
 
+Rate limits per route are separate from each other.  
+If you've sent 45 requests to `/steam` routes, you will still have the ability to send another 100 requests to `/twitch` routes.
+
 - `/twitch/*` - All sub-routes under `/twitch`
     - Limit: 100 requests per 60 seconds.
+- `/steam/*` - All sub-routes under `/steam`
+    - Limit: 45 requests per 60 seconds.
 
 ## License
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -85,7 +85,7 @@ Route::group(['prefix' => 'random', 'as' => 'random.'], function() {
         ->where('max', '((-)?[\d]+)');
 });
 
-Route::group(['prefix' => 'steam', 'as' => 'steam.'], function() {
+Route::group(['prefix' => 'steam', 'as' => 'steam.', 'middleware' => 'ratelimit:' . env('STEAM_THROTTLE_RATE_LIMIT', '45,1')], function() {
     Route::get('connect/{appId?}/{parameters?}', ['as' => 'connect', 'uses' => 'SteamController@connect'])
         ->where('appId', '[\d]{1,8}')
         ->where('parameters', '.*');

--- a/routes/web.php
+++ b/routes/web.php
@@ -85,7 +85,7 @@ Route::group(['prefix' => 'random', 'as' => 'random.'], function() {
         ->where('max', '((-)?[\d]+)');
 });
 
-Route::group(['prefix' => 'steam', 'as' => 'steam.', 'middleware' => 'ratelimit:' . env('STEAM_THROTTLE_RATE_LIMIT', '45,1')], function() {
+Route::group(['prefix' => 'steam', 'as' => 'steam.', 'middleware' => 'ratelimit:' . env('STEAM_THROTTLE_RATE_LIMIT', '15,1')], function() {
     Route::get('connect/{appId?}/{parameters?}', ['as' => 'connect', 'uses' => 'SteamController@connect'])
         ->where('appId', '[\d]{1,8}')
         ->where('parameters', '.*');


### PR DESCRIPTION
I've noticed an increased amount of errors in logs due to `429 Too Many Requests` from the Steam API.  
While I originally noticed it as an issue many months ago, it was infrequent and didn't really seem like an issue.  
Now I'm noticing multiple errors every day, and it's causing issues.

From what I can tell, there might be a way for me to increase my rate limit for my Steam API key, but for now I'll have to implement a rate limit and see if it helps.