### PR TITLE
Fixes repeated host message when using limit parameter for hosts

### DIFF
--- a/resources/lang/de/twitch.php
+++ b/resources/lang/de/twitch.php
@@ -46,7 +46,7 @@ return [
      * Hosting
      */
     'no_hosts' => 'Aktuell wird :channel von niemandem gehostet.',
-    'multiple_hosts' => ':channels und :amount weiterer|:channels und :amount weitere',
+    'multiple_hosts' => ':channels und :amount weiterer.',
 
     /**
      * Multi

--- a/resources/lang/en/twitch.php
+++ b/resources/lang/en/twitch.php
@@ -47,7 +47,7 @@ return [
      * Hosting
      */
     'no_hosts' => 'No one is currently hosting :channel',
-    'multiple_hosts' => ':channels and :amount other|:channels and :amount others',
+    'multiple_hosts' => ':channels and :amount others.',
 
     /**
      * Multi

--- a/resources/lang/no/twitch.php
+++ b/resources/lang/no/twitch.php
@@ -35,5 +35,5 @@ return [
      * Hosting
      */
     'no_hosts' => 'Det er foreløpig ingen som hoster :channel',
-    'multiple_hosts' => ':channels og :amount annen|:channels og :amount andre',
+    'multiple_hosts' => ':channels og :amount annen.',
 ];

--- a/resources/lang/ru/twitch.php
+++ b/resources/lang/ru/twitch.php
@@ -48,7 +48,7 @@ return [
      * Hosting
      */
     'no_hosts' => 'Никто не хостит канал :channel',
-    'multiple_hosts' => ':channels и :amount другой|:channels и :amount других',
+    'multiple_hosts' => ':channels и :amount другой.',
 
     /**
      * Multi


### PR DESCRIPTION
When attempting to add the `limit` parameter for the Twitch `hosts` endpoint, the following would occur:

Example URL: `https://decapi.me/twitch/hosts/myth?limit=3`
Response: `fortnitehypedeutsch, vuptr, imperfectvisuals and 7155 other|fortnitehypedeutsch, vuptr, imperfectvisuals and 7155 others`

This fixes the duplicate message. Note that for `en`, it was `other` and not `others` which I changed. However this may need to be reviewed for `de`, `no`, and `ru`, as I simply added a `.` and removed the duplicate message from those translation files.