### PR TITLE
[Twitch] Remove `@` characters from the beginning of `channel` / `user` parameters

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -56,5 +56,6 @@ class Kernel extends HttpKernel
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'ratelimit' => \App\Http\Middleware\RateLimitWithWhitelist::class,
+        'twitch.remove_at_signs' => \App\Http\Middleware\TwitchRemoveAtSigns::class,
     ];
 }

--- a/app/Http/Middleware/TwitchRemoveAtSigns.php
+++ b/app/Http/Middleware/TwitchRemoveAtSigns.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+
+class TwitchRemoveAtSigns
+{
+    /**
+     * Removes one or more '@' characters from the beginning
+     * of the string, if they are there.
+     *
+     * In this scenario it should just remove the first `@` characters
+     * before merging the new strings back into the existing request.
+     *
+     * @param string $value
+     *
+     * @return string
+     */
+    private function removeAtSigns($value)
+    {
+        return ltrim($value, '@');
+    }
+
+    /**
+     * Remove leading `@` characters for specific
+     * parameters (mainly `channel` and `user`).
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $old = $request->all();
+
+        /**
+         * Neither `channel` or `user` is specified
+         * So we don't need to modify anything.
+         */
+        if (!isset($old['channel']) && !isset($old['user'])) {
+            return $next($request);
+        }
+
+        /**
+         * Store new values that should be merged into the request.
+         */
+        $new = [];
+
+        /**
+         * Replace for `channel` parameter, if it's set.
+         */
+        if (isset($old['channel'])) {
+            $new['channel'] = $this->removeAtSigns($old['channel']);
+        }
+
+        /**
+         * Replace for `user` parameter, if it's set.
+         */
+        if (isset($old['user'])) {
+            $new['user'] = $this->removeAtSigns($old['user']);
+        }
+
+        /**
+         * Merge/replace the new strings into the request.
+         */
+        $request->replace($new);
+
+        return $next($request);
+    }
+}

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -17,13 +17,42 @@ class RouteServiceProvider extends ServiceProvider
     protected $namespace = 'App\Http\Controllers';
 
     /**
+     * Removes one or more '@' characters from the beginning
+     * of the string, if they are there.
+     *
+     * Primarily targeted towards /twitch routes where
+     * `@` is used to mention Twitch usernames and thus causing a 404.
+     *
+     * In this scenario it should just remove the first `@` characters and continue
+     * passing the value to the controller.
+     *
+     * @param string $value
+     *
+     * @return string
+     */
+    private function removeAtSigns($value)
+    {
+        return ltrim($value, '@');
+    }
+
+    /**
      * Define your route model bindings, pattern filters, etc.
      *
      * @return void
      */
     public function boot()
     {
-        //
+        /**
+         * Remove one or more '@' if they're at the
+         * beginning of the parameter.
+         */
+        Route::bind('channel', function($channel) {
+            return $this->removeAtSigns($channel);
+        });
+
+        Route::bind('user', function($user) {
+            return $this->removeAtSigns($user);
+        });
 
         parent::boot();
     }


### PR DESCRIPTION
Helpful for those commands where people use `@` to auto-complete usernames.

Should in theory not break anything, as `@`-prefixes aren't used for anything else Twitch-related.

*Needs a little bit more testing before I merge*