### PR TITLE
[Twitch] Update remaining APIs to Helix

### DIFF
--- a/app/Http/Controllers/TwitchController.php
+++ b/app/Http/Controllers/TwitchController.php
@@ -973,22 +973,18 @@ class TwitchController extends Controller
             }
         }
 
-        $fetchHighlight = $this->twitchApi->videos($request, $channel, ['highlight'], 1, 0, $this->version);
+        $highlights = $this->api->channelVideos($channel, 'highlight');
 
-        if (!empty($fetchHighlight['status'])) {
-            return Helper::text($fetchHighlight['message']);
-        }
-
-        if (empty($fetchHighlight['videos'])) {
+        if (empty($highlights)) {
             return Helper::text(__('twitch.no_highlights', [
                 'channel' => ($channelName ?: $channel)
             ]));
         }
 
-        $highlight = $fetchHighlight['videos'][0];
+        $highlight = $highlights[0];
         $title = $highlight['title'];
         $url = $highlight['url'];
-        return Helper::text($title . ' - ' . $url);
+        return Helper::text(sprintf('%s - %s', $title, $url));
     }
 
     /**
@@ -1004,7 +1000,6 @@ class TwitchController extends Controller
         $channel = $channel ?: $request->input('channel', null);
         $channelName = null;
         $limit = intval($request->input('count', 100));
-        $offset = intval($request->input('offset', 0));
         $id = $request->input('id', 'false');
 
         if (empty($channel)) {
@@ -1027,31 +1022,19 @@ class TwitchController extends Controller
             }
         }
 
-        $data = $this->twitchApi->videos($request, $channel, ['highlight'], $limit, $offset, $this->version);
+        $highlights = $this->api->channelVideos($channel, 'highlight', $limit);
 
-        if (!empty($data['status'])) {
-            return Helper::text($data['message'], $data['status']);
-        }
-
-        if (empty($data['videos'])) {
+        if (empty($highlights)) {
             return Helper::text(__('twitch.no_highlights', ['channel' => ($channelName ?: $channel)]));
         }
 
-        $highlights = $data['videos'];
         $random = array_rand($highlights);
-        $vid = $highlights[$random];
-        $format = '%s: %s';
-        $text = [
-            $vid['title'],
-            $vid['url']
-        ];
+        $video = $highlights[$random];
 
-        if ($request->exists('game')) {
-            array_unshift($text, $vid['game']);
-            $format = '%s - ' . $format;
-        }
+        $title = $video['title'];
+        $url = $video['url'];
 
-        return Helper::text(vsprintf($format, $text));
+        return Helper::text(sprintf('%s - %s', $title, $url));
     }
 
     /**

--- a/app/Http/Controllers/TwitchController.php
+++ b/app/Http/Controllers/TwitchController.php
@@ -127,8 +127,8 @@ class TwitchController extends Controller
     protected function userByName($name)
     {
         try {
-            return $this->twitchApi->userByName($name);
-        } catch (Exception $e) {
+            return $this->api->userByName($name);
+        } catch (TwitchApiException $e) {
             throw $e;
         }
     }

--- a/app/Http/Controllers/TwitchController.php
+++ b/app/Http/Controllers/TwitchController.php
@@ -230,7 +230,6 @@ class TwitchController extends Controller
             'title' => 'title/{CHANNEL}',
             'team_members' => 'team_members/{TEAM_ID}',
             'total_views' => 'total_views/{CHANNEL}',
-            'upload' => 'upload/{CHANNEL}',
             'uptime' => 'uptime/{CHANNEL}',
             'viewercount' => 'viewercount/{CHANNEL}',
             'videos' => 'videos/{CHANNEL}',
@@ -2054,55 +2053,6 @@ class TwitchController extends Controller
         }
 
         return Helper::text($data['view_count']);
-    }
-
-    /**
-     * Finds the specified channel's latest video upload.
-     *
-     * @param  Request $request
-     * @param  String  $channel Channel name
-     * @return Response
-     */
-    public function upload(Request $request, $channel = null)
-    {
-        $id = $request->input('id', 'false');
-        $channelName = null;
-
-        if (empty($channel)) {
-            $nb = new Nightbot($request);
-            if (empty($nb->channel)) {
-                return Helper::text(__('generic.channel_name_required'));
-            }
-
-            $channel = $nb->channel['providerId'];
-            $id = 'true';
-        }
-
-        if ($id !== 'true') {
-            try {
-                // Store channel name separately and override $channel
-                $channelName = $channel;
-                $channel = $this->userByName($channel)->id;
-            } catch (Exception $e) {
-                return Helper::text($e->getMessage());
-            }
-        }
-
-        $video = $this->twitchApi->videos($request, $channel, ['upload'], 1, 0, $this->version);
-
-        if (!empty($video['status'])) {
-            return Helper::text($video['message']);
-        }
-
-        if (empty($video['videos'])) {
-            return Helper::text(__('twitch.no_uploads', [
-                'channel' => ($channelName ?: $channel),
-            ]));
-        }
-
-        $upload = $video['videos'][0];
-        $text = sprintf('%s - %s', $upload['title'], $upload['url']);
-        return Helper::text($text);
     }
 
     /**

--- a/app/Http/Resources/Twitch/Video.php
+++ b/app/Http/Resources/Twitch/Video.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Resources\Twitch;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class Video extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        $video = $this->resource;
+
+        return [
+            'id' => $video['id'],
+            'stream_id' => $video['stream_id'],
+            'user_id' => $video['user_id'],
+            'user_login' => $video['user_login'],
+            'user_name' => $video['user_name'],
+            'title' => $video['title'],
+            'description' => $video['description'],
+            'created_at' => $video['created_at'],
+            'published_at' => $video['published_at'],
+            'url' => $video['url'],
+            'thumbnail_url' => $video['thumbnail_url'],
+            'viewable' => $video['viewable'],
+            'view_count' => $video['view_count'],
+            'language' => $video['language'],
+            'type' => $video['type'],
+            'duration' => $video['duration'],
+            'muted_segments' => $video['muted_segments'] ?? [],
+        ];
+    }
+}

--- a/app/Http/Resources/Twitch/VideoCollection.php
+++ b/app/Http/Resources/Twitch/VideoCollection.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources\Twitch;
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class VideoCollection extends ResourceCollection
+{
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return $this->collection
+                    ->map
+                    ->toArray($request)
+                    ->all();
+    }
+}

--- a/config/twitch.php
+++ b/config/twitch.php
@@ -47,6 +47,11 @@
              * `channel_emotes` specifies minutes via `addMinutes()`.
              */
             'channel_emotes' => 60,
+
+            /**
+             * Used by `channelVideos()` in TwitchApiRepository.
+             */
+            'channel_videos' => 180,
         ],
     ];
 ?>

--- a/config/twitch.php
+++ b/config/twitch.php
@@ -27,6 +27,11 @@
             'status' => 60,
 
             /**
+             * Follower count of a channel
+             */
+            'followcount' => 60,
+
+            /**
              * Subscriptions meta API handler.
              * Currently being used for subpoints/subcount and it's *shared*.
              *

--- a/resources/lang/en/twitch.php
+++ b/resources/lang/en/twitch.php
@@ -17,7 +17,7 @@ return [
      * Related to followers
      */
     'cannot_follow_self' => 'A user cannot follow themself.',
-    'error_followers' => 'An error occurred retrieving your followers.',
+    'error_followers' => 'An error has occurred retrieving followers for :channel',
     'follow_not_found' => ':user does not follow :channel',
     'no_followers' => 'You do not have any followers :(',
     'invalid_api_data' => 'Twitch API returned invalid data.',

--- a/resources/lang/no/twitch.php
+++ b/resources/lang/no/twitch.php
@@ -13,7 +13,7 @@ return [
      * Related to followers
      */
     'cannot_follow_self' => 'En bruker kan ikke følge seg selv.',
-    'error_followers' => 'En feil oppstod ved henting av følgere.',
+    'error_followers' => 'En feil oppstod ved henting av følgere for kanal: :channel',
     'no_followers' => 'Du har ingen følgere :(',
     'invalid_api_data' => 'Twitch API returnerte ugyldig data.',
     'unable_get_following' => 'Får ikke hentet gyldig data for den oppgitte brukeren.',


### PR DESCRIPTION
More progress towards #22 

## Followage
- `/followage/{channel}/{user}` now uses Helix
- At the moment there's no caching for this endpoint, but I am debating on having a short cache shared with `/followed/{channel}/{user}`

## Followers
1. `/followers/{channel}` now uses Helix
2. JSON responses have been removed (from what I know it was infrequently used anyways)
3. Parameters that have been removed and are no longer supported (mainly due to lack of support in Helix)
	- `offset`
	- `cursor`
	- `direction`
	- `input` (used alongside JSON responses)
	- `username` (see point 4)
4. Names listed are now always "display names" and not "Twitch usernames". Helix API does not include usernames and _only_ display names.

## Following
Same as the `Followers` changes, really - as they use the same endpoint.

## Highlight / "Random Highlight"
Also updated to use Helix.
"Random highlight" has lost the ability to include the game name as Helix does not provide it. From what I know no one was using this functionality regardless.

## TODO
- Update `/following/{user}` to use Helix as well
- Add caching to `/twitch/followers` - Might have to take `count` into consideration.