### PR TITLE
[YouTube] Begin supporting filtering shorts and current active livestreams

### DIFF
--- a/app/Providers/YouTubeApiProvider.php
+++ b/app/Providers/YouTubeApiProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use App\Repositories\YouTubeApiRepository;
+
+class YouTubeApiProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     *
+     * @return void
+     */
+    public function register()
+    {}
+
+    /**
+     * Bootstrap services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->app->singleton(YouTubeApiRepository::class);
+    }
+}

--- a/app/Repositories/YouTubeApiRepository.php
+++ b/app/Repositories/YouTubeApiRepository.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Repositories;
+
+use Cache;
+use Carbon\CarbonInterval;
+use YouTube;
+
+class YouTubeApiRepository
+{
+    /**
+     * The cutoff point for shorts
+     *
+     * @var CarbonInterval
+     */
+    protected $shortsCutoff;
+
+    public function __construct()
+    {
+        $this->shortsCutoff = new CarbonInterval('PT1M');
+    }
+
+    /**
+     * Filters away any "shorts" videos (videos less than 1 minute long).
+     * Input is expected to be an array of videos, as returned by `getVideoDetails()`.
+     *
+     * @param array $videos
+     *
+     * @return array
+     */
+    public function filterShorts($videos = [])
+    {
+        $filteredVideos = [];
+
+        foreach ($videos as $id => $video) {
+            $duration = new CarbonInterval($video->contentDetails->duration);
+            if ($this->shortsCutoff->greaterThan($duration)) {
+                continue;
+            }
+
+            $filteredVideos[$id] = $video;
+        }
+
+        return $filteredVideos;
+    }
+
+    /**
+     * Gets *extended* video details for the given video IDs.
+     * This may serve video details from cache, but we're talking about things like the title, description, duration etc.
+     * Data that should not update very often.
+     *
+     * @param array $videoIds A list of YouTube video IDs
+     *
+     * @return array
+     */
+    public function getVideoDetails($videoIds = [])
+    {
+        $cacheFormat = 'youtube_video_details_%s';
+        $requestVideoIds = [];
+
+        // First we figure out which video IDs we need to request
+        foreach ($videoIds as $videoId) {
+            $cacheKey = sprintf($cacheFormat, $videoId);
+
+            if (Cache::has($cacheKey)) {
+                continue;
+            }
+
+            $requestVideoIds[] = $videoId;
+        }
+
+        // Then we request the video details for the video IDs we need
+        if (count($requestVideoIds) > 0) {
+            $videoDetails = YouTube::getVideoInfo($requestVideoIds);
+
+            foreach ($videoDetails as $videoDetail) {
+                $videoId = $videoDetail->id;
+                $cacheKey = sprintf($cacheFormat, $videoId);
+                Cache::put($cacheKey, $videoDetail, config('youtube-cache.video_details', 2592000));
+            }
+        }
+
+        // Finally we get the video details from the cache and put them in the `$videoDetails` array in order
+        $videoDetails = [];
+        foreach ($videoIds as $videoId) {
+            $cacheKey = sprintf($cacheFormat, $videoId);
+
+            if (Cache::has($cacheKey)) {
+                $videoDetails[$videoId] = Cache::get($cacheKey);
+            }
+        }
+
+        return $videoDetails;
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -173,6 +173,11 @@ return [
          * Currency data
          */
         App\Providers\CurrencyApiProvider::class,
+
+        /**
+         * YouTube
+         */
+        App\Providers\YouTubeApiProvider::class,
     ],
 
     /*

--- a/config/youtube-cache.php
+++ b/config/youtube-cache.php
@@ -5,4 +5,11 @@
          * Since this is primarily used for looking up music, it shouldn't cause many issues.
          */
         'search' => 10800,
+
+        /**
+         * Cache YouTube video details for 30 days (60 * 60 * 24 * 30)
+         * Specifically extended video details for when we request more information of a video ID,
+         * e.g. via latest_video
+         */
+        'video_details' => 2592000,
     ];


### PR DESCRIPTION
[Work in progress]

Adds two new parameters for the `/youtube/latest_video` endpoint:

- `no_shorts=1` - Will filter away any videos that are less than 1 minute / 60 seconds.
	- Closes #99 
- `no_livestream=1` - Will ignore any active livestream and not consider them the "latest video"
	- Keep in mind that this parameter **will not** filter away any stream VODs for completed livestreams.
- `include` - Similar to `exclude`, will only include videos that matches the "search term" in the `include` parameter.
	- This can be combined with `exclude` as well.
	- Closes #105 

Things that I also plan on adding:

- ~~`include` parameter - As mentioned in #105~~ - Added in d321291
- TBD: `max_duration` / `min_duration` - More precise filtering where you can choose to filter away any videos that are less than `min_duration` or longer than `max_duration`.
	- `max_duration` could theoretically be used to ignore any stream VODs.